### PR TITLE
add stream tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
 
       gtag('config', 'G-DHTXLNDNPV');
     </script>  
-    <!-- VIZLAB Google tag (gtag.js) -->
+    <!-- VIZLAB collective Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-FWMWJQHLM6"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -23,6 +23,15 @@
 
       gtag('config', 'G-FWMWJQHLM6');
     </script>
+    <!-- VIZLAB DATA STREAM Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-QV1JK700W8"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-QV1JK700W8');
+  </script>
     <!-- Primary Meta Tags -->
       <title>
         <%= VUE_APP_TIER %>


### PR DESCRIPTION
Comparing analytics data with different GA4 tags defined to viz and as data streams for a main viz tag. 