### PR TITLE
add and customize authorship component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -148,7 +148,12 @@ h3{
 p, text {
   font-family: $Assistant;
   font-size: 1em;
-  line-height: 0.8em;
+  @media screen and (max-width: 700px) {
+      font-size: 0.9em;
+  } 
+  @media screen and (max-height: 500px) {
+      font-size: 0.9em;
+  } 
 }
 a { 
   color: black;

--- a/src/assets/text/authors.js
+++ b/src/assets/text/authors.js
@@ -1,0 +1,100 @@
+export default {
+    // do not delete section. delete individuals as needed. modify content as needed
+    // currently only 'fullName', 'firstName', 'initials', 'profile_link', and 'contribution' are used
+    primaryAuthors: [
+      {
+        firstName: 'Hayley',
+        lastName: 'Corson-Dosch',
+        fullName: 'Hayley Corson-Dosch',
+        initials: 'HCD',
+        profile_link: 'https://www.usgs.gov/staff-profiles/hayley-corson-dosch',
+        role: 'lead designer',
+        contribution: '(she/her) led the design effort throughout the iterative design process and diagram review and contributed to social media development. She also developed this website'
+      },
+      {
+        firstName: 'Cee',
+        lastName: 'Nell',
+        fullName: 'Cee Nell',
+        initials: 'CN',
+        profile_link: 'https://www.usgs.gov/staff-profiles/cee-nell',
+        role: 'designer',
+        contribution: '(they/them), as the Vizlab team lead, contributed to the design work, provided oversight, and coordinated the formal scientific review of the diagram'
+      },
+      {
+        firstName: 'Althea',
+        lastName: 'Archer',
+        fullName: 'Althea Archer',
+        initials: 'AA',
+        profile_link: 'https://www.usgs.gov/staff-profiles/althea-archer',
+        role: 'designer',
+        contribution: '(she/her) contributed design work during the review stage'
+      },
+      {
+        firstName: 'Ellen',
+        lastName: 'Bechtel',
+        fullName: 'Ellen Bechtel',
+        initials: 'EB',
+        profile_link: null,
+        role: 'designer',
+        contribution: '(she/her), a former Vizlab team member, contributed key graphic design work during the initial design and planning stages'
+      }
+    ],
+    // do not delete section. delete any or all individuals as needed. modify content as needed
+    // currently only 'fullName', 'firstName', 'initials', 'profile_link', and 'contribution' are used
+    additionalAuthors: [
+      {
+        firstName: 'Rachel',
+        lastName: 'Volentine',
+        fullName: 'Rachel Volentine',
+        initials: 'RV',
+        profile_link: null,
+        role: 'contributor',
+        contribution: '(she/her) led usability testing'
+      },
+      {
+        firstName: 'Jen',
+        lastName: 'Bruce',
+        fullName: 'Jen Bruce',
+        initials: 'JB',
+        profile_link: 'https://www.usgs.gov/staff-profiles/jennifer-l-bruce',
+        role: 'contributor',
+        contribution: '(she/her) contributed to the product planning and design'
+      },
+      {
+        firstName: 'Nicole',
+        lastName: 'Felts',
+        fullName: 'Nicole Felts',
+        initials: 'NF',
+        profile_link: null,
+        role: 'contributor',
+        contribution: '(she/her) contributed to Water Science School web development and designed and led communications'
+      },
+      {
+        firstName: 'Rebekah',
+        lastName: 'Redwine',
+        fullName: 'Rebekah Redwine',
+        initials: 'RR',
+        profile_link: null,
+        role: 'contributor',
+        contribution: '(she/her) contributed to social media development and other communications'
+      },
+      {
+        firstName: 'Charlotte',
+        lastName: 'Riggs',
+        fullName: 'Charlotte Riggs',
+        initials: 'CR',
+        profile_link: null,
+        role: 'contributor',
+        contribution: '(she/her) contributed to usability testing, communications, and Water Science School web development and provided oversight and coordination'
+      },
+      {
+        firstName: 'Emily',
+        lastName: 'Read',
+        fullName: 'Emily Read',
+        initials: 'ER',
+        profile_link: 'https://www.usgs.gov/staff-profiles/emily-k-read',
+        role: 'contributor',
+        contribution: '(she/her) contributed to product planning and provided oversight'
+      }
+      ]
+};

--- a/src/assets/text/authors.js
+++ b/src/assets/text/authors.js
@@ -37,12 +37,8 @@ export default {
         profile_link: null,
         role: 'designer',
         contribution: '(she/her), a former Vizlab team member, contributed key graphic design work during the initial design and planning stages'
-      }
-    ],
-    // do not delete section. delete any or all individuals as needed. modify content as needed
-    // currently only 'fullName', 'firstName', 'initials', 'profile_link', and 'contribution' are used
-    additionalAuthors: [
-      {
+      },
+            {
         firstName: 'Rachel',
         lastName: 'Volentine',
         fullName: 'Rachel Volentine',
@@ -96,5 +92,9 @@ export default {
         role: 'contributor',
         contribution: '(she/her) contributed to product planning and provided oversight'
       }
+    ],
+    // do not delete section. delete any or all individuals as needed. modify content as needed
+    // currently only 'fullName', 'firstName', 'initials', 'profile_link', and 'contribution' are used
+    additionalAuthors: [
       ]
 };

--- a/src/components/Authorship.vue
+++ b/src/components/Authorship.vue
@@ -1,0 +1,84 @@
+<template>
+  <div id="author-container" v-if="showAuthors">
+    <p>
+      The design of the Water Cycle Diagram was led by the USGS 
+      <a href="https://labs.waterdata.usgs.gov/visualizations/vizlab-home/index.html#/" target="_blank">Vizlab</a>
+      , in colaboration with the Web Communications Branch and other USGS scientists.
+      <br>
+      <br>
+      <span id="contribution-statements" v-if="showContributionStatements">
+        Vizlab is a data visualization team in the Data Science Branch of the USGS Water Resources Mission Area that brings expertise in communicating complex data-driven topics through compelling visuals.
+        <span id="primary-author-contribution">
+          <span
+            v-for="author in primaryAuthors" 
+            :key="`${author.initials}-contribution`"
+            :id="`author-${author.initials}`"
+            :class="'author'"
+          >
+            <a v-bind:href="author.profile_link" target="_blank" v-text="author.fullName"></a> <span v-text="author.contribution"></span>. 
+          </span>
+        </span>
+        <br>
+        <br>
+        The Web Communications Branch of the USGS Water Resources Mission Area provided expertise in user-centered design, communications, outreach, and educational engagement.
+        <span id="additional-author-contribution"  v-if="showAditionalContributionStatement">
+          <span
+            v-for="author in additionalAuthors" 
+            :key="`${author.initials}-contribution`"
+            :id="`author-${author.initials}`"
+            :class="'author'"
+          >
+            <a v-bind:href="author.profile_link" target="_blank" v-text="author.fullName"></a> <span v-text="author.contribution"></span>. 
+          </span>
+        </span>
+      </span>
+    </p>
+  </div>
+</template>
+
+<script>
+import { isMobile } from 'mobile-device-detect';
+import authors from "@/assets/text/authors";
+export default {
+  name: "authorship",
+    components: {
+    },
+    props: {
+    },
+    data() {
+      return {
+        publicPath: process.env.BASE_URL, // allows the application to find the files when on different deployment roots
+        appTitle: process.env.VUE_APP_TITLE, // Pull in title of page from Vue environment (set in .env)
+        mobileView: isMobile, // test for mobile
+        primaryAuthors: authors.primaryAuthors,
+        additionalAuthors: authors.additionalAuthors,
+        showAuthors: null, // Turn on or off attribution for all authors
+        showAdditionalAuthors: null, // If showAuthors is true, turn on or off attribution for additional authors
+        showContributionStatements: true, // If showAuthors is true, turn on or off contribution statements for ALL authors
+        showAditionalContributionStatement: null // If showAuthors is true and if showContributionStatements is true, turn on or off contriubtion statements for ADDITIONAL authors
+      }
+    },
+    mounted(){   
+      console.log(this.appTitle)
+      this.showAuthors = this.primaryAuthors.length > 0 ? true: false; // Show author statements for any authors
+      this.showAdditionalAuthors =  this.additionalAuthors.length > 0 ? true : false; // Show author statements for additional authors if any are listed
+      this.showAditionalContributionStatement = this.additionalAuthors.length > 0 ? true : false; // Show contributions statements for additional authors if any are listed AND showContributionStatements is true
+    },
+    methods:{
+      isMobile() {
+              if(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+                  return true
+              } else {
+                  return false
+              }
+          }
+    }
+}
+</script>
+<style>
+#author-container {
+  height: auto;
+  padding: 0em 0.25em 0em 0.25em;
+  margin: 1rem 0.5rem 1rem 0.5rem;
+}
+</style>

--- a/src/components/Authorship.vue
+++ b/src/components/Authorship.vue
@@ -1,13 +1,43 @@
 <template>
   <div id="author-container" v-if="showAuthors">
     <p>
-      The design of the Water Cycle Diagram was led by the USGS 
-      <a href="https://labs.waterdata.usgs.gov/visualizations/vizlab-home/index.html#/" target="_blank">Vizlab</a>
+      The design of the USGS water cycle diagram was led by the  
+      <a href="https://labs.waterdata.usgs.gov/visualizations/vizlab-home/index.html#/" target="_blank">USGS Vizlab</a>
       , in colaboration with the Web Communications Branch and other USGS scientists.
       <br>
       <br>
+      <span id="primary-author-statment">
+        Contributors included 
+        <span
+          v-for="(author, index) in primaryAuthors" 
+          :key="`${author.initials}-attribution`"
+          :id="`initial-${author.initials}`"
+          :class="'author first'"
+        >
+          <a v-bind:href="author.profile_link" target="_blank" v-text="author.fullName"></a>
+          <span v-if="index != Object.keys(primaryAuthors).length - 1 && Object.keys(primaryAuthors).length > 2">, </span>
+          <span v-if="index == Object.keys(primaryAuthors).length - 2"> and </span>
+        </span>.
+      </span>
+      <span id="additional-author-statement" v-if="showAdditionalAuthors">
+        <span
+          v-for="(author, index) in additionalAuthors" 
+          :key="`${author.initials}-attribution`"
+          :id="`author-${author.initials}`"
+          :class="'author'"
+        >
+          <a v-bind:href="author.profile_link" Water Data for the Nation blog v-text="author.fullName"></a>
+          <span v-if="index != Object.keys(additionalAuthors).length - 1 && Object.keys(additionalAuthors).length > 2">, </span>
+          <span v-if="index == Object.keys(additionalAuthors).length - 2"> and </span>
+        </span>
+        <span>
+        also contributed to the site.
+        </span>
+      </span>
+      To learn more about the team and the design process, read the Water Data for the Nation blog post 
+      <a class="blog_title" href="https://waterdata.usgs.gov/blog/water-cycle-release/" target="_blank">A New Take on the Water Cycle</a>
+      .
       <span id="contribution-statements" v-if="showContributionStatements">
-        Vizlab is a data visualization team in the Data Science Branch of the USGS Water Resources Mission Area that brings expertise in communicating complex data-driven topics through compelling visuals.
         <span id="primary-author-contribution">
           <span
             v-for="author in primaryAuthors" 
@@ -18,9 +48,6 @@
             <a v-bind:href="author.profile_link" target="_blank" v-text="author.fullName"></a> <span v-text="author.contribution"></span>. 
           </span>
         </span>
-        <br>
-        <br>
-        The Web Communications Branch of the USGS Water Resources Mission Area provided expertise in user-centered design, communications, outreach, and educational engagement.
         <span id="additional-author-contribution"  v-if="showAditionalContributionStatement">
           <span
             v-for="author in additionalAuthors" 
@@ -54,7 +81,7 @@ export default {
         additionalAuthors: authors.additionalAuthors,
         showAuthors: null, // Turn on or off attribution for all authors
         showAdditionalAuthors: null, // If showAuthors is true, turn on or off attribution for additional authors
-        showContributionStatements: true, // If showAuthors is true, turn on or off contribution statements for ALL authors
+        showContributionStatements: false, // If showAuthors is true, turn on or off contribution statements for ALL authors
         showAditionalContributionStatement: null // If showAuthors is true and if showContributionStatements is true, turn on or off contriubtion statements for ADDITIONAL authors
       }
     },
@@ -75,10 +102,20 @@ export default {
     }
 }
 </script>
-<style>
+<style lang="scss" scoped>
+$diagramBlue: #016699;
 #author-container {
   height: auto;
   padding: 0em 0.25em 0em 0.25em;
   margin: 1rem 0.5rem 1rem 0.5rem;
+}
+a[href] {
+  color: $diagramBlue;
+}
+a[href]:hover {
+  font-weight: 700;
+}
+.blog_title {
+  font-style: italic;
 }
 </style>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,0 +1,162 @@
+<template>
+  <div class="sidebar collapsed opacity">
+    <div class="sidebarContent">
+      <div class="titleAndExit">
+        <h3>
+          <button
+            class="button reveal"
+            @click="toggle"
+          >
+            <slot name="sidebarTitle">
+              Contributors
+            </slot>
+          </button>
+        </h3>
+        <div
+          class="exit hidden"
+          @click="toggle"
+        >
+          <h3>
+            X
+          </h3>
+        </div>
+      </div>
+      <div class="messageArea">
+        <div class="message">
+          <slot name="sidebarMessage">
+            <authorship class="hidden"/>
+          </slot>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+export default {
+    name: "SidebarTwo",
+    components: {
+        authorship: () => import( /* webpackPreload: true */ /*webpackChunkName: "section"*/ "./../components/Authorship")
+    },
+    mounted(){
+        window.addEventListener("load", () => this.setDimensions());
+    },
+    methods:{
+        setDimensions(){
+            const sidebar = this.$el;
+            const button = this.$el.querySelector(".reveal")
+            const buttonDimensions = button.getBoundingClientRect();
+            sidebar.style.height = `${buttonDimensions.height}px`;
+            sidebar.style.width = `${buttonDimensions.width}px`;
+            sidebar.classList.remove("opacity");
+        },
+        toggle(){
+            const exit = this.$el.querySelector(".exit");
+            const sidebarButton = this.$el.querySelector(".reveal")
+            const authorText = this.$el.querySelector("#author-container")
+            exit.classList.toggle("hidden");
+            authorText.classList.toggle("hidden");
+            sidebarButton.classList.toggle("button");
+            if(this.$el.classList.contains("expanded")){ 
+                this.$el.classList.remove("expanded");
+                this.$el.classList.add("collapsed");
+                this.setDimensions();
+            }else{
+                this.$el.classList.remove("collapsed");
+                this.$el.classList.add("expanded");
+                this.$el.style.width = "auto";
+                this.$el.style.height = "auto";
+            }   
+        }
+    }
+}
+</script>
+<style lang="scss" scoped>
+$diagramBlue: #016699;
+.sidebar{
+    display: flex;
+    flex-direction: row;
+    transition: width 2s, height 2s, transform 2s;
+    will-change: width;
+    border-radius: 5px;
+    transition: opacity 0.3s;
+}
+.titleAndExit{
+    position: relative;
+}
+.expanded {
+  background: $diagramBlue;
+  margin: 0 5px 0 0 ;
+}
+.expanded h3 {
+  color: #fff;
+  padding: 5px 10px;
+}
+.button {
+    border-radius: 0.25rem;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    padding: 2.5px 5px 2.5px 5px;
+    max-width: 24rem;
+    background-color: white;
+    border: 0.5px solid #949494;
+    border-radius: 0.25rem;
+    -webkit-user-select: none; /* Safari */
+    -ms-user-select: none; /* IE 10 and IE 11 */
+    user-select: none; /* Standard syntax */
+  }
+  .button:hover {
+    background-color: $diagramBlue;
+    color: white;
+    @media screen and (max-width: 600px) {
+      background-color: white;
+      color: black;
+    }
+  }
+.opacity{
+  opacity: 0;
+}
+.exit{
+    position: absolute;
+    right: 5px;
+    top: 0;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1em;
+    padding: 5px;
+    border-radius: 5px;
+}
+.exit h3 {
+  border-radius: 5px;
+  line-height: 0.8em;
+  cursor: pointer;
+    &:hover{
+        font-weight: 700;
+    }
+}
+.messageArea{
+    padding:0 10px 10px 10px;
+}
+.message{
+    background: #fff;
+    padding: 10px;
+    *{
+      padding-top: 0;
+      margin-bottom: 10px;
+      &:last-child{
+        margin-bottom: 0;
+      }
+    }
+}
+.collapsed{
+    .message{
+        width: 0;
+        height: 0;
+        opacity: 0;
+    }
+}
+.hidden{
+    display: none;
+}
+</style>

--- a/src/components/WaterCycle.vue
+++ b/src/components/WaterCycle.vue
@@ -41,6 +41,8 @@
           @click="$refs.zoomer.zoomOut()"
         > - </button>
       </h3>
+      <h3 class = "optionsBar notButton"> | </h3>
+      <sidebar class="optionsBar"/>
     </div>
     <v-zoomer
       id="image-zoomer"
@@ -89,9 +91,6 @@
         >
       </picture>
     </v-zoomer>
-    <br>
-    <hr>
-    <authorship />
   </div>
 </template>
 
@@ -99,7 +98,7 @@
     export default {
         name: "WaterCyle",
         components: {
-          authorship: () => import( /* webpackPreload: true */ /*webpackChunkName: "section"*/ "./../components/Authorship")
+          sidebar: () => import( /* webpackPreload: true */ /*webpackChunkName: "section"*/ "./../components/Sidebar")
         },
         data () {
           return {

--- a/src/components/WaterCycle.vue
+++ b/src/components/WaterCycle.vue
@@ -89,12 +89,18 @@
         >
       </picture>
     </v-zoomer>
+    <br>
+    <hr>
+    <authorship />
   </div>
 </template>
 
 <script>
     export default {
         name: "WaterCyle",
+        components: {
+          authorship: () => import( /* webpackPreload: true */ /*webpackChunkName: "section"*/ "./../components/Authorship")
+        },
         data () {
           return {
             zoomed: false,
@@ -182,7 +188,7 @@ $diagramBlue: #016699;
   margin-left: 0.5rem;
 }
 #button-container {
-  padding-left: 0.5vw;
+  padding-left: 0.25em;
   display: flex;
   flex-wrap: wrap;
 }


### PR DESCRIPTION
This PR adds in the authorship component from Vue scratch and customizes it, adjusting the formatting and text to allow for the broader author description used in the [WDFN blog](https://waterdata.usgs.gov/blog/water-cycle-release/). I'm happy to edit this if a shorter authorship statement is preferred, but thought it might make sense to have the full attribution on the main Vizlab site for the water cycle.