### PR TITLE
Fix sizing of collapsed sidebar

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -43,8 +43,8 @@ export default {
     methods:{
         setDimensions(){
             const sidebar = this.$el;
-            const button = this.$el.querySelector(".reveal")
-            const buttonDimensions = button.getBoundingClientRect();
+            const buttonDiv = this.$el.querySelector(".titleAndExit")
+            const buttonDimensions = buttonDiv.getBoundingClientRect();
             sidebar.style.height = `${buttonDimensions.height}px`;
             sidebar.style.width = `${buttonDimensions.width}px`;
             sidebar.classList.remove("opacity");
@@ -103,6 +103,9 @@ $diagramBlue: #016699;
     -webkit-user-select: none; /* Safari */
     -ms-user-select: none; /* IE 10 and IE 11 */
     user-select: none; /* Standard syntax */
+    @media screen and (max-width: 600px) {
+      border: 1px solid #949494;
+    }
   }
   .button:hover {
     background-color: $diagramBlue;

--- a/src/components/WaterCycle.vue
+++ b/src/components/WaterCycle.vue
@@ -203,6 +203,9 @@ $diagramBlue: #016699;
     -webkit-user-select: none; /* Safari */
     -ms-user-select: none; /* IE 10 and IE 11 */
     user-select: none; /* Standard syntax */
+    @media screen and (max-width: 600px) {
+      border: 1px solid #949494;
+    }
   }
   .button:hover {
     background-color: $diagramBlue;

--- a/src/components/WaterCycle.vue
+++ b/src/components/WaterCycle.vue
@@ -12,6 +12,13 @@
       <h3 class="optionsBar notButton"> | </h3>
       <h3 class="optionsBar notButton">
         <a
+          href="https://labs.waterdata.usgs.gov/visualizations/pools-and-fluxes/index.html#/"
+          target="_blank"
+        >Explore the size of pools and fluxes</a>
+      </h3>
+      <h3 class="optionsBar notButton"> | </h3>
+      <h3 class="optionsBar notButton">
+        <a
           v-bind:href="downloadSite"
           target="_blank"
         >


### PR DESCRIPTION
This edits how the sizing of the collapsed 'Contributors' sidebar is set. Previously, the dimensions of the button itself was used to set the size of the collapsed sidebar, but that meant that the margins were not included  and the button was cut off by the next div:
![image](https://user-images.githubusercontent.com/54007288/217368791-140b1f32-f5a0-4968-9e4b-302119aead09.png)

Now, I'm using the dimensions of the div that _contains_ the button to set the size of the collapsed sidebar, so that margins are accounted for:
![image](https://user-images.githubusercontent.com/54007288/217368983-6175121c-7e3f-4d94-8b93-be668174cd7c.png)
